### PR TITLE
Downgrade Bootstrap to 4.6.0

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,9 +25,9 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
       rel="stylesheet"
-      integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl"
+      integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l"
       crossorigin="anonymous"
     >
     <title>React App</title>


### PR DESCRIPTION
## What?
Downgraded the Bootstrap version from 5.0.0-beta2 to 4.6.0.
## Why?
The `react-bootstrap` version I'm using only supports 4.6.0. Using the beta version broke some of the components.
## How?
I replaced the Bootstrap jsDelivr link in [index.html](https://github.com/preservedfish/calculator-app/blob/main/public/index.html) with the appropriate 4.6.0 version.