### PR TITLE
Fix calculation list failing to render

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ const App = () => {
     } catch (error) {
       setAlert(error.message);
     }
-  }, []);
+  }, [newCalculation]);
 
   const addCalculation = (event) => {
     event.preventDefault();

--- a/src/components/CalculationForm.js
+++ b/src/components/CalculationForm.js
@@ -25,6 +25,12 @@ const CalculationForm = ({
       You can use operators such as +, -, *, **, /, %. Parentheses and decimals
       work too.
     </Form.Text>
+    <Form.Text>
+      <i>
+        Past calculations are hidden to first-time visitors unless they enter a
+        calculation or refresh the page.
+      </i>
+    </Form.Text>
   </Form>
 );
 

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -41,8 +41,6 @@ const getCalculations = (setCalculations) => {
       setCalculations(
         transformedData.slice(0, transformedData.length <= 10 ? undefined : 10)
       );
-    } else {
-      throw new Error("Couldn't fetch calculations");
     }
   });
 };


### PR DESCRIPTION
## What?
Before, the calculation list would not render until the user refreshed the page. Now, although I haven't completely fixed the issue, the list will at least render if the user enters something.
## Why?
This is pretty important and can confuse the user if no calculations appear.
## How?
I changed the useEffect() hook to fire whenever newCalculation changes. I then added a disclaimer under the input box that the calculations won't appear unless the user enters a value or refreshes the page. Finally, I removed an error from [firebase.js](https://github.com/preservedfish/calculator-app/blob/main/src/services/firebase.js) since it wasn't being caught properly.