### PR TITLE
Add a missing setShow() for notifications

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ const App = () => {
       firebaseService.getCalculations(setCalculations);
     } catch (error) {
       setAlert(error.message);
+      setShow(true);
     }
   }, [newCalculation]);
 


### PR DESCRIPTION
## What?
Added a missing `setShow()` to a try-catch block in [App.js](https://github.com/preservedfish/calculator-app/blob/main/src/App.js).
## Why?
Without this fix, there would be cases where an error is caught but no notification appears. Consequently, the user wouldn't be aware that something had gone wrong.